### PR TITLE
[be] feat: add 2 first scrape tools

### DIFF
--- a/backend/src/mcp/server.ts
+++ b/backend/src/mcp/server.ts
@@ -1,4 +1,5 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { setSitemapTool, scrapeTechTool } from './tools/';
 
 function getServer() {
     const server = new McpServer({
@@ -11,23 +12,8 @@ function getServer() {
         }
     })
 
-    server.resource('test-resource',
-        'test://resource',
-        {
-            title: 'Test Resource',
-            description: 'Test resource for Model Context Protocol',
-            mimeType: 'application/json'
-        },
-        async (uri) => {
-            return {
-                contents: [{
-                    uri: uri.href,
-                    text: JSON.stringify({ message: 'This is a test resource' }),
-                    mimeType: 'application/json'
-                }]
-            }
-        }
-    )
+    scrapeTechTool(server);
+    setSitemapTool(server); 
 
     return server;
 }

--- a/backend/src/mcp/services/index.ts
+++ b/backend/src/mcp/services/index.ts
@@ -1,0 +1,7 @@
+import scrapeNpmPage from "./scrapeNpm";
+import scrapeRelatedLinks from "./scrapeRelatedLinks";
+
+export {
+    scrapeNpmPage, 
+    scrapeRelatedLinks
+}

--- a/backend/src/mcp/services/scrapeNpm.ts
+++ b/backend/src/mcp/services/scrapeNpm.ts
@@ -1,0 +1,31 @@
+import * as cheerio from 'cheerio';
+import { InfoType } from '../../types';
+
+const baseUrl = 'https://npmjs.com/package/'
+
+async function scrapeNpmPage(name: string): Promise<InfoType> {
+
+    const url = baseUrl + name;
+
+    try {
+        const res = await fetch(url);
+        const html = await res.text(); 
+        const $ = cheerio.load(html);
+
+        const repository = $('#repository-link').text().trim();
+        const homepage = $('#homePage-link').text().trim(); 
+
+        return {
+            repository: `https://${repository}`,
+            homepage: `https://${homepage}`
+        }
+    } catch (error) {
+        console.error(`Error scraping ${url}:`, error);
+        return {
+            repository: "",
+            homepage: ""
+        }
+    }
+}
+
+export default scrapeNpmPage

--- a/backend/src/mcp/services/scrapeRelatedLinks.ts
+++ b/backend/src/mcp/services/scrapeRelatedLinks.ts
@@ -1,0 +1,31 @@
+import { PlaywrightCrawler } from 'crawlee';
+import { DocLink } from '../../types';
+
+const scrapeRelatedLinks = async (page_urls: string[], maxRequest: number = 7): Promise<DocLink[]> => {
+    const data: DocLink[] = [];
+
+    try {
+        const crawler = new PlaywrightCrawler({
+            async requestHandler({ request, page, enqueueLinks, log }) {
+                const title = await page.title();
+                // log.info(`Title of ${request.loadedUrl} is '${title}'`);
+
+                data.push({
+                    url: request.loadedUrl,
+                    name: title
+                })
+
+                await enqueueLinks();
+            },
+            maxRequestsPerCrawl: maxRequest,
+        });
+
+        await crawler.run(page_urls);
+    } catch {
+        console.log("Failed to scrape website");
+    } 
+
+    return data;
+}
+
+export default scrapeRelatedLinks

--- a/backend/src/mcp/tools/index.ts
+++ b/backend/src/mcp/tools/index.ts
@@ -1,0 +1,7 @@
+import scrapeTechTool from "./scrapeTechTool";
+import setSitemapTool from "./setSitemapTool";
+
+export {
+    scrapeTechTool, 
+    setSitemapTool
+}

--- a/backend/src/mcp/tools/scrapeTechTool.ts
+++ b/backend/src/mcp/tools/scrapeTechTool.ts
@@ -1,0 +1,42 @@
+import { z } from 'zod';
+import { InfoType } from '../../types';
+import { scrapeNpmPage } from '../services';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+
+const scrapeTechTool = (server: McpServer) => {
+    server.tool(
+        "scrape-tech",
+        "Scraping a tech's basic information (repository and homepage link) from npmjs",
+        {
+            name: z.string()
+        },
+        {
+            title: "Scrape Tech",
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false
+        },
+        async ({ name }) => {
+            let info: InfoType = {
+                repository: "",
+                homepage: ""
+            }
+
+            try {
+                info = await scrapeNpmPage(name);
+            } catch (e) {
+                console.error('Failed to get tech info', e);
+            }
+
+            return {
+                content: [{
+                    type: "text",
+                    text: JSON.stringify(info)
+                }]
+            }
+        }
+    )
+}
+
+export default scrapeTechTool;

--- a/backend/src/mcp/tools/setSitemapTool.ts
+++ b/backend/src/mcp/tools/setSitemapTool.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp';
+import { DocLink } from '../../types';
+import { scrapeRelatedLinks } from '../services';
+
+const setSitemapTool = (server: McpServer) => {
+    server.tool(
+        "set-sitemap",
+        "Scraping related links from a given link and set sitemap",
+        {
+            startLink: z.string()
+        },
+        {
+            title: "Set Sitemap",
+            readOnlyHint: false,
+            destructiveHint: false,
+            idempotentHint: false,
+            openWorldHint: false
+        },
+        async ({ startLink }) => {
+            let links: DocLink[] = []
+
+            try {
+                links = await scrapeRelatedLinks([startLink]);
+            } catch (e) {
+                console.error('Failed to get tech info', e);
+            }
+
+            return {
+                content: [{
+                    type: "text",
+                    text: JSON.stringify(links)
+                }]
+            }
+        }
+    )
+}
+
+export default setSitemapTool;

--- a/backend/src/routes/mcpRoute.ts
+++ b/backend/src/routes/mcpRoute.ts
@@ -25,7 +25,7 @@ router.post('/', async (req: Request, res: Response) => {
         console.error('Error handling MCP request:', error);
         if (!res.headersSent) {
             res.status(500).json({
-                jsonrpc: '2.0', 
+                jsonrpc: '2.0',
                 error: {
                     code: -32603,
                     message: 'Internal server error'

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,9 +1,9 @@
-import 'dotenv/config'; 
+import 'dotenv/config';
 import express from 'express';
 import cors from 'cors';
 import { config } from './config/';
 import route from './routes/';
-import mongoose from 'mongoose';
+// import mongoose from 'mongoose';
 
 const app = express();
 
@@ -13,21 +13,22 @@ app.use(express.urlencoded({ extended: true }));
 
 const allowedOrigins = [
     "http://localhost:8080", // dev - frontend
-    "http://http://127.0.0.1:6274/", // dev - mcp inspector
+    "http://localhost:5173", // dev - frontend
+    "http://127.0.0.1:6274", // dev - mcp inspector
     "https://stag-secure-widely.ngrok-free.app", // dev - ngrok 
 ]
 
 app.use(cors({
     origin: (origin, callback) => {
-        if (!origin || allowedOrigins.includes(origin)) callback(null, true) 
-        else callback(new Error('Not allowed by CORS'), false) 
-    }, 
-    methods: ['GET', 'POST', 'PUT', 'DELETE'], 
-    credentials: true, 
-})); 
+        if (!origin || allowedOrigins.includes(origin)) callback(null, true)
+        else callback(new Error('Not allowed by CORS'), false)
+    },
+    methods: ['GET', 'POST', 'PUT', 'DELETE'],
+    credentials: true,
+}));
 
 // Routes 
-route(app); 
+route(app);
 
 // Connect to database
 // mongoose.connect(process.env.MONGODB_URI || config.dbUrl) 

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,17 @@
+type StorageType = Record<string, DocLink[]>
+
+type DocLink = {
+    name: string; 
+    url: string; 
+}
+
+type InfoType = {
+    repository: string; 
+    homepage: string;
+}
+
+export type {
+    StorageType, 
+    DocLink, 
+    InfoType
+}

--- a/backend/storage/key_value_stores/default/SDK_CRAWLER_STATISTICS_0.json
+++ b/backend/storage/key_value_stores/default/SDK_CRAWLER_STATISTICS_0.json
@@ -1,0 +1,29 @@
+{
+  "requestsFinished": 5,
+  "requestsFailed": 0,
+  "requestsRetries": 0,
+  "requestsFailedPerMinute": 0,
+  "requestsFinishedPerMinute": 23,
+  "requestMinDurationMillis": 1775,
+  "requestMaxDurationMillis": 8469,
+  "requestTotalFailedDurationMillis": 0,
+  "requestTotalFinishedDurationMillis": 16250,
+  "crawlerStartedAt": "2025-08-12T07:52:39.956Z",
+  "crawlerFinishedAt": "2025-08-12T07:52:52.936Z",
+  "statsPersistedAt": "2025-08-12T07:52:52.936Z",
+  "crawlerRuntimeMillis": 13102,
+  "crawlerLastStartTimestamp": 1754985159834,
+  "requestRetryHistogram": [
+    5
+  ],
+  "statsId": 0,
+  "requestAvgFailedDurationMillis": null,
+  "requestAvgFinishedDurationMillis": 3250,
+  "requestTotalDurationMillis": 16250,
+  "requestsTotal": 5,
+  "requestsWithStatusCode": {
+    "200": 5
+  },
+  "errors": {},
+  "retryErrors": {}
+}

--- a/backend/storage/key_value_stores/default/SDK_SESSION_POOL_STATE.json
+++ b/backend/storage/key_value_stores/default/SDK_SESSION_POOL_STATE.json
@@ -1,0 +1,249 @@
+{
+  "usableSessionsCount": 6,
+  "retiredSessionsCount": 0,
+  "sessions": [
+    {
+      "id": "session_HnXiw6Ypri",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": []
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:40.521Z",
+      "createdAt": "2025-08-12T07:52:40.521Z",
+      "usageCount": 0,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    },
+    {
+      "id": "session_flFegYMhVY",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": [
+          {
+            "key": "_attrb",
+            "value": "013c6e61-9701-4d74-80ad-c7f2fe95a1a3",
+            "expires": "2026-08-12T07:52:51.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.731Z"
+          },
+          {
+            "key": "ph_phc_eNuN6Ojnk9O7uWfC17z12AK85fNR0BY6IiGVy0Gfwzw_posthog",
+            "value": "%7B%22distinct_id%22%3A%2201989d44-7987-73f2-ae38-15a9ab0ad6f0%22%2C%22%24sesid%22%3A%5B1754985171818%2C%2201989d44-7985-7e4c-ae05-efd6c4ed52d3%22%2C1754985167237%5D%2C%22%24initial_person_info%22%3A%7B%22r%22%3A%22%24direct%22%2C%22u%22%3A%22https%3A%2F%2Fmintlify.com%2F%22%7D%7D",
+            "expires": "2026-08-12T07:52:52.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "secure": true,
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "_gcl_au",
+            "value": "1.1.2138732529.1754985167",
+            "expires": "2025-11-10T07:52:47.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.731Z"
+          },
+          {
+            "key": "_ga_NZ6RFCB9LN",
+            "value": "GS2.1.s1754985167$o1$g1$t1754985172$j55$l0$h0",
+            "expires": "2026-09-16T07:52:52.055Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "_ga",
+            "value": "GA1.1.395526339.1754985168",
+            "expires": "2026-09-16T07:52:52.444Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "IndrXzk4dU01aEg4X0Nvb2VMcjhaM2ZSTDM5UTFyeHRxbzVmZWpRS2huM3FMX2Fub255bW91c1VzZXJJZCI%3D",
+            "value": "IjNjOWI4ZTRjLWU3YmQtNDA1NC1iYmMzLTMyNjAzODYxMmM4NyI=",
+            "expires": "2026-08-12T07:52:51.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.923Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "__hstc",
+            "value": "214098760.3fba500af1f9ddf561d502054348997d.1754985168911.1754985168911.1754985168911.1",
+            "expires": "2026-02-08T07:52:52.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.924Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "hubspotutk",
+            "value": "3fba500af1f9ddf561d502054348997d",
+            "expires": "2026-02-08T07:52:52.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.924Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "__hssrc",
+            "value": "1",
+            "expires": "2025-08-12T08:42:52.731Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.925Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "__hssc",
+            "value": "214098760.2.1754985168911",
+            "expires": "2025-08-12T08:22:52.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:48.925Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "_ga_RCYWHL7EQ7",
+            "value": "GS2.1.s1754985170$o1$g1$t1754985172$j58$l0$h0",
+            "expires": "2026-09-16T07:52:52.455Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:50.906Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          },
+          {
+            "key": "ph_phc_TXdpocbGVeZVm5VJmAsHTMrCofBQu3e0kN8HGMNGTVW_posthog",
+            "value": "%7B%22distinct_id%22%3A%2201989d44-8666-7b90-82a4-67d36d7f90a3%22%2C%22%24sesid%22%3A%5B1754985172415%2C%2201989d44-8664-7e29-ac10-2476fda3f1b7%22%2C1754985170532%5D%7D",
+            "expires": "2026-08-12T07:52:52.000Z",
+            "domain": "mintlify.com",
+            "path": "/",
+            "secure": true,
+            "hostOnly": false,
+            "creation": "2025-08-12T07:52:50.906Z",
+            "lastAccessed": "2025-08-12T07:52:52.732Z"
+          }
+        ]
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:40.524Z",
+      "createdAt": "2025-08-12T07:52:40.524Z",
+      "usageCount": 5,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    },
+    {
+      "id": "session_d4jr4l9J3j",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": []
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:49.051Z",
+      "createdAt": "2025-08-12T07:52:49.051Z",
+      "usageCount": 0,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    },
+    {
+      "id": "session_z9DcxHRctc",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": []
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:49.052Z",
+      "createdAt": "2025-08-12T07:52:49.052Z",
+      "usageCount": 0,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    },
+    {
+      "id": "session_3dYRGa4hJs",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": []
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:50.538Z",
+      "createdAt": "2025-08-12T07:52:50.538Z",
+      "usageCount": 0,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    },
+    {
+      "id": "session_6zjNzcZxTv",
+      "cookieJar": {
+        "version": "tough-cookie@5.1.2",
+        "storeType": "MemoryCookieStore",
+        "rejectPublicSuffixes": true,
+        "enableLooseMode": false,
+        "allowSpecialUseDomain": true,
+        "prefixSecurity": "silent",
+        "cookies": []
+      },
+      "userData": {},
+      "maxErrorScore": 3,
+      "errorScoreDecrement": 0.5,
+      "expiresAt": "2025-08-12T08:42:51.002Z",
+      "createdAt": "2025-08-12T07:52:51.002Z",
+      "usageCount": 0,
+      "maxUsageCount": 50,
+      "errorScore": 0
+    }
+  ]
+}

--- a/backend/storage/request_queues/default/UD802ACI777E3DY.json
+++ b/backend/storage/request_queues/default/UD802ACI777E3DY.json
@@ -1,0 +1,9 @@
+{
+	"id": "UD802ACI777E3DY",
+	"json": "{\"id\":\"UD802ACI777E3DY\",\"url\":\"https://mintlify.com/docs\",\"loadedUrl\":\"https://mintlify.com/docs\",\"uniqueKey\":\"https://mintlify.com/docs\",\"method\":\"GET\",\"noRetry\":false,\"retryCount\":0,\"errorMessages\":[],\"headers\":{},\"userData\":{\"__crawlee\":{\"crawlDepth\":1,\"enqueueStrategy\":\"same-hostname\",\"state\":4}},\"handledAt\":\"2025-08-12T07:52:50.964Z\"}",
+	"method": "GET",
+	"orderNo": null,
+	"retryCount": 0,
+	"uniqueKey": "https://mintlify.com/docs",
+	"url": "https://mintlify.com/docs"
+}

--- a/backend/storage/request_queues/default/XsEuzyhDIKnWAkJ.json
+++ b/backend/storage/request_queues/default/XsEuzyhDIKnWAkJ.json
@@ -1,0 +1,9 @@
+{
+	"id": "XsEuzyhDIKnWAkJ",
+	"json": "{\"id\":\"XsEuzyhDIKnWAkJ\",\"url\":\"https://mintlify.com/docs/api-playground\",\"loadedUrl\":\"https://mintlify.com/docs/api-playground/overview\",\"uniqueKey\":\"https://mintlify.com/docs/api-playground\",\"method\":\"GET\",\"noRetry\":false,\"retryCount\":0,\"errorMessages\":[],\"headers\":{},\"userData\":{\"__crawlee\":{\"crawlDepth\":1,\"enqueueStrategy\":\"same-hostname\",\"state\":4}},\"handledAt\":\"2025-08-12T07:52:52.558Z\"}",
+	"method": "GET",
+	"orderNo": null,
+	"retryCount": 0,
+	"uniqueKey": "https://mintlify.com/docs/api-playground",
+	"url": "https://mintlify.com/docs/api-playground"
+}

--- a/backend/storage/request_queues/default/lIwbPjXUQlkJ1MM.json
+++ b/backend/storage/request_queues/default/lIwbPjXUQlkJ1MM.json
@@ -1,0 +1,9 @@
+{
+	"id": "lIwbPjXUQlkJ1MM",
+	"json": "{\"id\":\"lIwbPjXUQlkJ1MM\",\"url\":\"https://mintlify.com/\",\"loadedUrl\":\"https://mintlify.com/\",\"uniqueKey\":\"https://mintlify.com\",\"method\":\"GET\",\"noRetry\":false,\"retryCount\":0,\"errorMessages\":[],\"headers\":{},\"userData\":{\"__crawlee\":{\"state\":4}},\"handledAt\":\"2025-08-12T07:52:48.988Z\"}",
+	"method": "GET",
+	"orderNo": null,
+	"retryCount": 0,
+	"uniqueKey": "https://mintlify.com",
+	"url": "https://mintlify.com/"
+}

--- a/backend/storage/request_queues/default/qtUCowOBY3sJgyr.json
+++ b/backend/storage/request_queues/default/qtUCowOBY3sJgyr.json
@@ -1,0 +1,9 @@
+{
+	"id": "qtUCowOBY3sJgyr",
+	"json": "{\"id\":\"qtUCowOBY3sJgyr\",\"url\":\"https://mintlify.com/docs/content/components/\",\"loadedUrl\":\"https://mintlify.com/docs\",\"uniqueKey\":\"https://mintlify.com/docs/content/components\",\"method\":\"GET\",\"noRetry\":false,\"retryCount\":0,\"errorMessages\":[],\"headers\":{},\"userData\":{\"__crawlee\":{\"crawlDepth\":1,\"enqueueStrategy\":\"same-hostname\",\"state\":4}},\"handledAt\":\"2025-08-12T07:52:51.109Z\"}",
+	"method": "GET",
+	"orderNo": null,
+	"retryCount": 0,
+	"uniqueKey": "https://mintlify.com/docs/content/components",
+	"url": "https://mintlify.com/docs/content/components/"
+}

--- a/backend/storage/request_queues/default/uVcysfo0mknV00k.json
+++ b/backend/storage/request_queues/default/uVcysfo0mknV00k.json
@@ -1,0 +1,9 @@
+{
+	"id": "uVcysfo0mknV00k",
+	"json": "{\"id\":\"uVcysfo0mknV00k\",\"url\":\"https://mintlify.com/customers\",\"loadedUrl\":\"https://mintlify.com/customers\",\"uniqueKey\":\"https://mintlify.com/customers\",\"method\":\"GET\",\"noRetry\":false,\"retryCount\":0,\"errorMessages\":[],\"headers\":{},\"userData\":{\"__crawlee\":{\"crawlDepth\":1,\"enqueueStrategy\":\"same-hostname\",\"state\":4}},\"handledAt\":\"2025-08-12T07:52:52.773Z\"}",
+	"method": "GET",
+	"orderNo": null,
+	"retryCount": 0,
+	"uniqueKey": "https://mintlify.com/customers",
+	"url": "https://mintlify.com/customers"
+}


### PR DESCRIPTION
**Tasks Done** 
+ Remove testing code 
+ Add tools: 
  - `scrapeTechTool()` --> Scrape npmjs page, return tech's repository and homepage links 
  - `setSitemapTool()` --> Scrape related links from a start link (use case: scrape related links from homepage link) 

**Note** 
- Logic copypasta from `/mcp` 
- MCP server is a part of this backend server `/backend`, so from now, the `/mcp` folder is for testing purpose and develop an isolate MCP server (will be used to develop MCP connected to VSCode, Claude, ...) 